### PR TITLE
fix(scripts): keep $PROJECT_DIR intact when it contains a space

### DIFF
--- a/scripts/upload_fs_after_upload.py
+++ b/scripts/upload_fs_after_upload.py
@@ -1,5 +1,6 @@
 Import("env")
 
+import subprocess
 from pathlib import Path
 
 
@@ -7,16 +8,26 @@ def upload_filesystem(source, target, env):
     project_dir = Path(env.subst("$PROJECT_DIR"))
     fs_image = project_dir / ".pio" / "build" / env.subst("${PIOENV}") / "littlefs.bin"
 
+    # Build the argument vector ourselves instead of handing SCons a command
+    # string: SCons splits on whitespace, so a $PROJECT_DIR containing a space
+    # would arrive at PlatformIO as two separate arguments.
+    def run_pio(pio_target):
+        subprocess.run(
+            [
+                env.subst("$PYTHONEXE"),
+                "-m", "platformio", "run",
+                "-t", pio_target,
+                "-d", str(project_dir),
+            ],
+            check=True,
+        )
+
     if not fs_image.is_file():
         print("LittleFS image missing; building filesystem first")
-        env.Execute("$PYTHONEXE -m platformio run -t buildfs -d $PROJECT_DIR")
+        run_pio("buildfs")
 
-    env.Execute(
-        env.VerboseAction(
-            "$PYTHONEXE -m platformio run -t uploadfs -d $PROJECT_DIR",
-            "Uploading LittleFS (bell.wav)...",
-        )
-    )
+    print("Uploading LittleFS (bell.wav)...")
+    run_pio("uploadfs")
 
 
 env.AddPostAction("upload", upload_filesystem)


### PR DESCRIPTION
Fixes #19.

`pio run -t upload` fails during the filesystem step whenever the project path contains a
space — the firmware uploads, then both `buildfs` and `uploadfs` die with:

```
Error: Invalid value for '-d' / '--project-dir': Path 'E:\Users\Jon\Downloads\Tiny' does not exist.
```

so the device boots without its audio assets.

### Why

Both PlatformIO calls were command **strings**. SCons tokenizes those on whitespace
*after* substituting `$PROJECT_DIR` into them, so the path arrives split at its first
space.

### Why not just add quotes

Both of the obvious one-line fixes fail. Reproduced against SCons 4.11.1 with
`env.subst_list(cmd, SCons.Subst.SUBST_CMD)`:

| Attempt | Result |
| --- | --- |
| `-d $PROJECT_DIR` (current) | 9 argv entries, path split at the space |
| `-d "$PROJECT_DIR"` | still split, and the `"` characters stay attached to the tokens — a stray quote now sits *inside* the path |
| `env.Execute([...])` with a list | still split; SCons re-tokenizes each element after substituting it (11 entries instead of 10) |

### The change

Build the argument vector in Python and spawn it with `subprocess.run`, so nothing
re-splits it. The two call sites become one small helper.

### Verification

No hardware needed for the tokenization itself. Driving the real post-action with a
stubbed `env` whose `$PROJECT_DIR` contains a space now yields an intact path:

```
argv: ['C:\\py\\python.exe', '-m', 'platformio', 'run', '-t', 'buildfs',
       '-d', 'E:\\Users\\Jon\\Downloads\\Tiny Engineer\\tiny-engineer-0.1.0']
  arg count: 8      -d value intact: True
```

(before: 9 entries, `-d` = `E:\Users\Jon\Downloads\Tiny`)

### One judgement call to flag

I added `check=True`, so a failing `buildfs` now aborts the build instead of being
ignored and letting `uploadfs` run anyway. That is a small behaviour change beyond the
literal bug — happy to drop it if you would rather keep this strictly to the path fix.
