### PR TITLE
docs: give the serial port per platform, not just the macOS form

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,9 +58,16 @@ Several serial ports:
 
 ```bash
 pio device list
-pio run -t upload --upload-port /dev/cu.usbserial-XXXX
-pio device monitor --port /dev/cu.usbserial-XXXX
+pio run -t upload --upload-port <PORT>
+pio device monitor --port <PORT>
 ```
+
+`<PORT>` is the name `pio device list` prints for the board, and it is
+platform-specific: `COM4` on Windows, `/dev/cu.usbmodemXXXX` or
+`/dev/cu.usbserial-XXXX` on macOS, `/dev/ttyACM0` or `/dev/ttyUSB0` on Linux.
+Pick the entry whose hardware ID shows Espressif's `VID:PID=303A:1001` (the
+ESP32-C3's native USB) or your board's USB-serial bridge — `pio device list`
+also lists Bluetooth serial ports, which are not the board.
 
 ### 5. Wi‑Fi setup
 


### PR DESCRIPTION
The multi-port snippet in `docs/getting-started.md` offers only the macOS form:

```bash
pio run -t upload --upload-port /dev/cu.usbserial-XXXX
pio device monitor --port /dev/cu.usbserial-XXXX
```

On Windows that gets copied verbatim — `XXXX` and all — and esptool fails with a path
error that reads like a driver or cable fault rather than a wrong port name:

```
Serial port /dev/cu.usbserial-XXX
A fatal error occurred: Could not open /dev/cu.usbserial-XXXX:,
 the port is busy or doesn't exist.
(could not open port '/dev/cu.usbserial-XXXX': FileNotFoundError(2, 'The system cannot find the path specified.', None, 3))

Hint: Check if the port is correct and ESP connected
```

Everything before that succeeds — build, size check, protocol selection — so the failure
lands at the very end of a long, healthy-looking run.

### Change

Use a `<PORT>` placeholder and name the form for each platform (Windows `COM4`, macOS
`/dev/cu.usbmodemXXXX` / `/dev/cu.usbserial-XXXX`, Linux `/dev/ttyACM0` / `/dev/ttyUSB0`).

Also point at the VID:PID to select by. `pio device list` lists Bluetooth serial ports
next to the board, and on Windows they sort first — the real board here was the second
entry:

```
COM3  Standard Serial over Bluetooth link
COM4  USB Serial Device — USB VID:PID=303A:1001
```

Docs only; no code touched. Independent of #20.