### PR TITLE
feat(rgb): identify the failed subsystem with a red blink code

### DIFF
--- a/docs/hardware/testing.md
+++ b/docs/hardware/testing.md
@@ -26,6 +26,22 @@ Build/flash: project root README (`pio run`, `pio run -t upload`, serial 115200)
 | Servos | Smooth move to mid (or sleep pose) at 35°/s |
 | HTTP | Port 80 if Wi-Fi connected |
 | Success | Dim green RGB during init; then animation LED (see below) |
+| Fatal init failure | Red blink code on the WS2812 (see below) |
+
+## Boot-failure blink codes
+
+A fatal init failure halts boot and blinks the onboard WS2812 red. The number of
+flashes before the long gap identifies the subsystem:
+
+| Blinks | Meaning |
+| --- | --- |
+| 1 | PCA9685 not found on I2C `0x40` |
+| 2 | MAX98357A / I2S init failed |
+
+Each flash is 300 ms on, 300 ms off; the gap between repeats is 3 s, so the start of a
+cycle is easy to find. Serial carries the same message, but the blink code is readable
+with no cable attached — and with `serial_log` off (the default) the serial line is
+silent, which makes the LED the only signal a first-boot board gives you.
 
 ## Expected boot sequence
 

--- a/src/hardware/pca9685_servos.cpp
+++ b/src/hardware/pca9685_servos.cpp
@@ -24,11 +24,7 @@ void initPca9685() {
       "Not found"
     );
 
-    setRgb(64, 0, 0);
-
-    while (true) {
-      delay(1000);
-    }
+    haltWithRgbCode(RGB_CODE_PCA9685);
   }
 
   serialLogPrintln("PCA9685 found");

--- a/src/hardware/rgb.cpp
+++ b/src/hardware/rgb.cpp
@@ -13,6 +13,12 @@ constexpr uint8_t RGB_ANIM_WHITE = 255;
 constexpr uint8_t RGB_ANIM_RED = 255;
 constexpr uint32_t RGB_TRANSITION_MS = 1000;
 
+// Boot-failure blink codes. The gap is 10x the pause between blinks within a
+// train, so the cycle boundary stays unmistakable as more codes are added: even
+// a long count reads as one group followed by an obvious silence.
+constexpr uint32_t RGB_CODE_BLINK_MS = 300;
+constexpr uint32_t RGB_CODE_GAP_MS = 3000;
+
 constexpr uint8_t RGB_PULSE_MIN = 26;   // ~10% of 255
 constexpr uint8_t RGB_PULSE_MAX = 255;  // 100%
 constexpr uint32_t RGB_PULSE_PHASE_MS = 500;
@@ -250,6 +256,19 @@ void updateRgb(uint32_t nowMs) {
   }
 
   applyTransition(nowMs);
+}
+
+void haltWithRgbCode(uint8_t blinks) {
+  while (true) {
+    for (uint8_t i = 0; i < blinks; i++) {
+      setRgb(64, 0, 0);
+      delay(RGB_CODE_BLINK_MS);
+      setRgb(0, 0, 0);
+      delay(RGB_CODE_BLINK_MS);
+    }
+
+    delay(RGB_CODE_GAP_MS);
+  }
 }
 
 void runRgbTest() {

--- a/src/hardware/rgb.h
+++ b/src/hardware/rgb.h
@@ -4,7 +4,14 @@
 
 #include "animation.h"
 
+// Boot-failure blink codes: how many red flashes before the long gap.
+constexpr uint8_t RGB_CODE_PCA9685 = 1;
+constexpr uint8_t RGB_CODE_I2S = 2;
+
 void setRgb(uint8_t r, uint8_t g, uint8_t b);
+
+// Blinks red `blinks` times, pauses, and repeats forever. Never returns.
+[[noreturn]] void haltWithRgbCode(uint8_t blinks);
 void setRgbForAnimation(AnimationId id, uint32_t nowMs);
 void updateRgb(uint32_t nowMs);
 void runRgbTest();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,11 +108,7 @@ void setup() {
       "Init failed"
     );
 
-    setRgb(64, 0, 0);
-
-    while (true) {
-      delay(1000);
-    }
+    haltWithRgbCode(RGB_CODE_I2S);
   }
 
   serialLogPrintln("I2S OK");


### PR DESCRIPTION
## Why

Both fatal init failures currently halt with the same solid red:

```c
setRgb(64, 0, 0);

while (true) {
  delay(1000);
}
```

So the LED says "boot failed" but not *where*. That matters more than it looks, because of how the two failure paths interact with logging:

- `SETTINGS_DEFAULT_SERIAL_LOG` is `false`, and every boot message goes through the gated `serialLogPrintln()`.
- On a board whose NVS has never been written, `Preferences.begin()` fails with `NOT_FOUND` and the defaults apply — so serial logging is **off**.
- Both halts sit *before* Wi-Fi comes up, so the HTTP settings API that could turn logging on is unreachable.

The result is a board that halts, prints nothing about why, and cannot be told to start printing. I hit exactly this: my PCA9685 was not yet wired, the board halted at `initPca9685()`, and the only serial output in a 25-second capture was one `nvs_open failed: NOT_FOUND` line from `Preferences` — which bypasses the gate. Everything else, including `ERROR: PCA9685 not found`, was suppressed.

The LED is the only signal such a board gives you, so it should carry which subsystem failed.

## What this does

Adds `haltWithRgbCode()` and routes both halts through it:

```c
void haltWithRgbCode(uint8_t blinks) {
  while (true) {
    for (uint8_t i = 0; i < blinks; i++) {
      setRgb(64, 0, 0);
      delay(RGB_CODE_BLINK_MS);
      setRgb(0, 0, 0);
      delay(RGB_CODE_BLINK_MS);
    }

    delay(RGB_CODE_GAP_MS);
  }
}
```

| Blinks | Meaning | Call site |
| --- | --- | --- |
| 1 | PCA9685 not found on I2C `0x40` | `initPca9685()` |
| 2 | MAX98357A / I2S init failed | `setup()` |

Codes are named constants in `rgb.h`, so the table lives in one place and adding a subsystem is a constant plus a call.

**On the timings:** flashes are 300 ms on / 300 ms off, and the gap between repeats is 3000 ms — deliberately 10x the in-train pause. That keeps the cycle boundary unmistakable as codes are added; even an 8-blink train (4.8 s) is still followed by a longer silence. A short gap is what makes high counts unreadable, so the ratio is the part worth preserving if you want different numbers.

Each halt site drops from five lines to one call, and `haltWithRgbCode()` becomes the only `while (true)` in `src/`.

## Behaviour change

Previously: solid red forever. Now: blinking red forever. Both remain a permanent halt, and the serial messages are untouched — this only adds information to the LED.

## Testing

Hardware: Waveshare ESP32-C3-Zero, PlatformIO env `esp32-c3-devkitm-1`, platform Espressif 32 `55.3.311`, Arduino-ESP32 `3.3.11`.

- `pio run` clean on this branch.
- Flashed with the PCA9685 absent (I2C bus scan returned 0 devices across addresses 1-126): board blinks **once** per cycle, matching `RGB_CODE_PCA9685`. Confirmed visually.
- The 2-blink I2S path is code-identical and shares the same helper, but I have not been able to trigger it on hardware — my MAX98357A is not wired yet, and boot halts at the PCA9685 check first.

## Note

While testing this I found that on my C3-Zero the WS2812 is RGB-ordered rather than GRB, so `setRgb(64, 0, 0)` renders as green. That is filed separately as #22 and is **not** part of this PR — this change is orthogonal and works either way, the flashes just come out green on affected units until #22 is resolved.
